### PR TITLE
Github Actions Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Run Gradle on PRs
+on: pull_request
+jobs:
+  gradle:
+    runs-on: "ubuntu-latest"
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - run: 
+        ./gradlew build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+on:
+   release: 
+     types: [created]
+jobs:
+  generate:
+    name: Create release-artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@master
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build the artifacts
+        run: ./gradlew build
+      - name: Upload the artifacts
+        uses: skx/github-action-publish-binaries@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: build/libs/primalmagic*.jar

--- a/build.gradle
+++ b/build.gradle
@@ -6,14 +6,16 @@ buildscript {
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
+        classpath group: 'com.palantir.gradle.gitversion', name: 'gradle-git-version', version: '0.12.2'
     }
 }
 apply plugin: 'net.minecraftforge.gradle'
 // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
+apply plugin: 'com.palantir.git-version'
 
-version = '0.0.1'
+version = gitVersion()
 group = 'com.verdantartifice.primalmagic' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'primalmagic'
 


### PR DESCRIPTION
For your consideration, two github actions that may help you in future.

First action is a build check - runs on any PR and runs a cached gradle
build to see if we compile

Second action runs when a release is created through the API or releases
tab; it similarly runs a gradle build, and uploads jars found in the
build/lib dir as assets to the release, making them available there.

In order to make sure the output matches git versioning used for the
release tab, gradle's been taught to version artifacts based on git
version; it'll use x.y.z-shorthash[.dirty] naming - .dirty if you built
with uncommited changes in the tree.

Github actions come with a couple risks to be accepted consciously:
* Anyone with write access to the repo (external contributors with
write/push access, usually) can add new actions while actions are
enabled; these actions have access to a github access token that has
access to the repo. - basically, if they have write, they have repo
control. Usually an expected state of being. Don't give write access to
anyone you don't trust.
* This publish action is based on a third-party org's action; all the
release-asset support I could find in actions/ didn't seem to offer a
clean way to get the release ID out or in. Surprising to me. Means you
need to make sure you trust the org, or otherwise are okay with the
risk. If you want to mitigate, you can fork the action into your org and
point at your local copy instead. (all the actions/ actions are
maintained by github.com. if you don't trust them, you're screwed
already)
* Build costs - 2000-3000 free minutes is a lot for one project, but worth noting.

Anycase, this was fun for me to sort.  

If you'd like to see what this looks like running,
https://github.com/dreamlibrarian/PrimalMagic/actions shows the job executions - they appear in PRs as status checks.

https://github.com/dreamlibrarian/PrimalMagic/releases/tag/0.0.4 shows where the published artifact appears.